### PR TITLE
cmaes 0.9.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,26 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
+    - python
     - numpy
-    - python >=3.7
 
 test:
   imports:
     - cmaes
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/CyberAgentAILab/cmaes
@@ -32,7 +38,9 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
+  description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   dev_url: https://github.com/CyberAgentAILab/cmaes
+  doc_url: https://github.com/CyberAgentAILab/cmaes
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/BayesWitnesses/m2cgen/releases
License: https://github.com/CyberAgentAILab/cmaes/blob/v0.9.1/LICENSE
Requirements: https://github.com/CyberAgentAILab/cmaes/blob/v0.9.1/pyproject.toml

Actions:
1. Remove `noarch python`
2. Skip p`y<37`
3. Add flags `--no-deps --no-build-isolation` to `script`
4. Add missing `setuptools` and `wheel` to `host`
5. Fix `python` in `host` and `run`
6. Add pip check
7. Add `description` 
8. Add doc url

Notes:
- pycaret 3.0.2 (subpackage pycaret-tuners) relies on `optuna` which requires `cmaes >=0.9.1`  https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements-optional.txt#L25